### PR TITLE
Security fixes: SSR XSS, shopping-list IDOR, and hardening

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,8 +1,10 @@
 import hashlib
+import hmac
 import io
 import json
 import logging
 import os
+import re
 import threading
 from datetime import timedelta
 from typing import Any, Literal, OrderedDict, cast
@@ -42,6 +44,7 @@ app.secret_key = bytes(os.environ["FLASK_KEY"], "utf-8").decode("unicode_escape"
 app.config["SESSION_TYPE"] = "redis"
 app.config["SESSION_REDIS"] = redis.Redis(host="redis", port=6379, db=2)
 app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+app.config["SESSION_COOKIE_SECURE"] = True
 app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=365)
 app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 365 * 24 * 60 * 60
 
@@ -56,6 +59,13 @@ redisNotificationsDB = redis.StrictRedis(host="redis", port=6379, db=0)
 redisUniqueRecipeDB = redis.StrictRedis(host="redis", port=6379, db=1)
 redisShoppingListDB = redis.StrictRedis(
     host="redis", port=6379, db=2, decode_responses=True
+)
+
+# Shared shopping lists are referenced by a client-generated UUID. We match that
+# format so a shared id can never collide with a private list (keyed by the bare
+# username) or a flask-session key (prefixed "session:") in the same redis db.
+SHOPPING_LIST_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
 )
 
 checksumRequestParser = reqparse.RequestParser()
@@ -239,9 +249,28 @@ def privateShoppingList():
         return unauthorized()
 
 
+def resolveShoppingListKey(list_id: str) -> str | None:
+    """Map a requested list id to its redis key, or None if access is denied.
+
+    - The caller's own private list (key == bare username) is only served to the
+      authenticated owner.
+    - Shared lists are public-by-link but namespaced under "shared:" so a shared
+      id can never address a private (bare-username) list or a flask-session key.
+    """
+    user_name = sessionGet("userName")
+    if user_name is not None and list_id == user_name:
+        return list_id
+    if SHOPPING_LIST_ID_RE.fullmatch(list_id):
+        return f"shared:{list_id}"
+    return None
+
+
 @app.route("/shoppingLists/<string:list_id>", methods=["GET", "POST", "PUT", "DELETE"])
 def publicShoppingList(list_id: str):
-    return handleShoppingList(list_id)
+    key = resolveShoppingListKey(list_id)
+    if key is None:
+        return unauthorized()
+    return handleShoppingList(key)
 
 
 @app.route("/webpush_public_key", methods=["GET"])
@@ -249,13 +278,18 @@ def get_push_public_key():
     return make_response(jsonify({"public_key": os.environ["PUSH_PUBLIC_KEY"]}), 200)
 
 
-def notifyNewRecipe(recipe: OrderedDict[str, Any], exclude: int):
+def notifyNewRecipe(recipe: OrderedDict[str, Any], exclude: int, author: str):
     logger.info(f"sending notifications, but not to {exclude=}")
+    groups = db.getUserGroups()
+    authorGroup = groups.get(author)
     for sub in redisNotificationsDB.scan_iter():
         try:
             if sub.decode() == exclude:
                 continue
             value = json.loads(redisNotificationsDB.get(sub))  # type: ignore
+            # only notify subscribers in the same group as the recipe's author
+            if groups.get(value.get("userName")) != authorGroup:
+                continue
             webpush(
                 subscription_info=value["sub"],
                 data=json.dumps(recipe),
@@ -480,7 +514,11 @@ class RecipeListAPI(Resource):
         if result is not None:
             t = threading.Thread(
                 target=notifyNewRecipe,
-                kwargs={"recipe": result, "exclude": sessionGet("id", -1)},
+                kwargs={
+                    "recipe": result,
+                    "exclude": sessionGet("id", -1),
+                    "author": userName,
+                },
             )
             t.start()
             return result
@@ -522,9 +560,9 @@ class RecipeAPI(Resource):
 
     # only for express to load the preview
     def get(self, recipeId: int):
-        if (
-            "express-secret" in request.headers
-            and request.headers["express-secret"] == os.environ["EXPRESS_SECRET"]
+        if "express-secret" in request.headers and hmac.compare_digest(
+            request.headers["express-secret"].encode(),
+            os.environ["EXPRESS_SECRET"].encode(),
         ):
             result = db.getRecipe(recipeId)
             if result is not None:
@@ -596,6 +634,9 @@ class CategoryListAPI(Resource):
 # images
 IMAGE_FOLDER = "../images/"
 
+# guard against decompression-bomb images (PIL raises DecompressionBombError above)
+Image.MAX_IMAGE_PIXELS = 64_000_000
+
 
 class ImageListAPI(Resource):
     def post(self):
@@ -626,7 +667,7 @@ class ImageListAPI(Resource):
                 response.status_code = 201
                 response.autocorrect_location_header = False
                 return response
-            except IOError as e:
+            except (IOError, Image.DecompressionBombError) as e:
                 logger.error(e)
                 return make_response(jsonify({"error": "File isn't an image"}), 400)
 
@@ -651,15 +692,18 @@ class ImageAPI(Resource):
                 im.save(output, format="JPEG")
             output.seek(0)
             return send_file(output, download_name="img.jpg", mimetype="image/jpeg")
-        except IOError:
+        except (IOError, Image.DecompressionBombError):
             abort(404)
 
     def delete(self, name: str):
         userName = sessionGet("userName")
         if userName is None:
             return unauthorized()
-        if os.path.exists(IMAGE_FOLDER + name):
-            os.remove(IMAGE_FOLDER + name)
+        if not db.hasWriteAccess(userName):
+            return make_response(jsonify({"error": "no write access"}), 403)
+        if not os.path.exists(IMAGE_FOLDER + name):
+            return make_response("", 404)
+        os.remove(IMAGE_FOLDER + name)
         return make_response(jsonify(), 200)
 
 

--- a/api/migrate_shopping_lists.py
+++ b/api/migrate_shopping_lists.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""One-time migration: namespace shared shopping lists under a "shared:" prefix.
+
+Before the access-control fix, shared shopping lists were stored in redis (db 2)
+under their bare UUID, sharing a keyspace with private lists (keyed by the bare
+username) and flask sessions (keyed "session:..."). This script renames each
+bare-UUID hash key to "shared:<uuid>" so the new key-resolution logic in app.py
+finds them again.
+
+Safe to run repeatedly: already-prefixed keys and non-UUID / non-hash keys are
+skipped. Run once after deploying the fix, e.g.:
+
+    docker compose exec api python migrate_shopping_lists.py
+
+If skipped, shared lists simply start empty and repopulate as items are re-added.
+"""
+
+import re
+
+import redis
+
+SHOPPING_LIST_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+)
+
+
+def main() -> None:
+    r = redis.StrictRedis(host="redis", port=6379, db=2, decode_responses=True)
+
+    migrated = 0
+    for key in r.scan_iter():
+        if not SHOPPING_LIST_ID_RE.fullmatch(key):
+            continue
+        if r.type(key) != "hash":
+            continue
+        target = f"shared:{key}"
+        if r.exists(target):
+            print(f"skip {key}: {target} already exists")
+            continue
+        r.rename(key, target)
+        migrated += 1
+        print(f"renamed {key} -> {target}")
+
+    print(f"done, migrated {migrated} shared list(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/api/util.py
+++ b/api/util.py
@@ -351,7 +351,10 @@ class Database:
         try:
             hash = pbkdf2_sha256.hash(pwd)
             cur = conn.cursor()
-            query = "INSERT INTO `user` (`user`, `encrypted`, `readOnly`) VALUES (%s, %s, '0');"
+            query = (
+                "INSERT INTO `user` (`user`, `encrypted`, `readOnly`, `groupId`) "
+                "VALUES (%s, %s, '0', 0);"
+            )
             if cur.execute(query, [username, hash]) == 1:
                 return True
         finally:
@@ -367,5 +370,15 @@ class Database:
             for res in cur.fetchall():
                 return res["readOnly"] == 0
             return False
+        finally:
+            conn.close()
+
+    def getUserGroups(self):
+        """Return a {username: groupId} map for scoping notifications by group."""
+        conn, _, _ = self.connect()
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT `user`, `groupId` FROM `user`;")
+            return {res["user"]: res["groupId"] for res in cur.fetchall()}
         finally:
             conn.close()

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -61,6 +61,9 @@ http {
         add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header X-Robots-Tag "none" always;
         add_header X-XSS-Protection "1; mode=block" always;
+        # Content-Security-Policy: shipped in Report-Only first to validate against
+        # the running SPA, then switch the header name to Content-Security-Policy.
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'" always;
         # Remove X-Powered-By, which is an information leak
 
         location = /robots.txt {

--- a/ui/client/e2e/fixtures.ts
+++ b/ui/client/e2e/fixtures.ts
@@ -40,8 +40,13 @@ export const SEED_RECIPES = [
 export const IMAGED_RECIPE_TITLE = SEED_RECIPES[0].title;
 export const SEED_COMMENT = 'E2E seed comment for popover tests.';
 
-/** Fixed share key + name for the public shopping-list route. */
-export const SEED_LIST_KEY = 'e2e-fixed-listkey-0001';
+/**
+ * Fixed share key + name for the public shopping-list route. The key must be a
+ * UUID: the client only ever creates shared lists via uuidv4(), and the API now
+ * requires shared-list ids to be UUID-shaped so they can never collide with a
+ * private list (keyed by the bare username).
+ */
+export const SEED_LIST_KEY = '00000000-0000-4000-8000-000000000001';
 export const SEED_LIST_NAME = 'E2E Groceries';
 
 export const SEED_LIST_ITEMS = [

--- a/ui/server/package-lock.json
+++ b/ui/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/express": "^5.0.6",
         "@types/morgan": "^1.9.10",
+        "escape-html": "^1.0.3",
         "express": "^5.2.1",
         "morgan": "^1.11.0",
         "node-fetch": "^3.3.2",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@types/escape-html": "^1.0.4",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
         "jiti": "^2.6.1",
@@ -254,6 +256,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@types/escape-html": "^1.0.4",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
     "jiti": "^2.6.1",
@@ -28,6 +29,7 @@
   "dependencies": {
     "@types/express": "^5.0.6",
     "@types/morgan": "^1.9.10",
+    "escape-html": "^1.0.3",
     "express": "^5.2.1",
     "morgan": "^1.11.0",
     "node-fetch": "^3.3.2",

--- a/ui/server/src/server.ts
+++ b/ui/server/src/server.ts
@@ -5,6 +5,7 @@ import { readFile } from 'fs';
 import util from 'util';
 import { IApiRecipe } from './types.js';
 import morgan from 'morgan';
+import escapeHtml from 'escape-html';
 
 const readFileAsync = util.promisify(readFile);
 
@@ -12,7 +13,10 @@ const app = express();
 const port = process.env.PORT ?? 3000;
 const apiUri = process.env.API_URI ?? 'http://localhost:3040/api/';
 const staticDir = process.env.STATIC_DIR ?? '../client/dist';
-const expressSecret = process.env.EXPRESS_SECRET ?? 'Apple';
+const expressSecret = process.env.EXPRESS_SECRET;
+if (!expressSecret) {
+  throw new Error('Missing required env variable EXPRESS_SECRET');
+}
 
 app.use(morgan('short'));
 
@@ -27,9 +31,15 @@ app.get('/shoppingLists/*slug', async (req, res) => {
   console.log(`${req.url}`);
   const name = req.url.split('/').at(-1);
   if (name) {
+    let decodedName: string;
+    try {
+      decodedName = decodeURI(name);
+    } catch {
+      decodedName = name;
+    }
     const index = (await readFileAsync(resolve(staticDir, 'index.html'), 'utf-8')).replaceAll(
       /(<meta\s+(?:property|name)="[^"]*description"\s+content=")[^"]*(">)/g,
-      (_, p1, p2) => `${p1}Einkaufsliste ${decodeURI(name)}${p2}`,
+      (_, p1, p2) => `${p1}Einkaufsliste ${escapeHtml(decodedName)}${p2}`,
     );
     res.send(index);
   } else {
@@ -46,27 +56,29 @@ app.get(['/uniqueRecipes/*slug', '/recipes/*slug'], async (req, res) => {
     const recipe = (await result.json()) as IApiRecipe;
     let index = await readFileAsync(resolve(staticDir, 'index.html'), 'utf-8');
 
-    // replace title
+    // replace title (escape user-controlled content to prevent HTML injection)
+    const safeTitle = escapeHtml(recipe.title);
     index = index
       .replaceAll(
         /(<meta\s+(?:property|name)="[^"]*title"\s+content=")[^"]*(">)/g,
-        (_, p1, p2) => `${p1}${recipe.title}${p2}`,
+        (_, p1, p2) => `${p1}${safeTitle}${p2}`,
       )
-      .replace(/(<title>)[^>]*<\/title>/, `<title>${recipe.title}</title>`);
+      .replace(/(<title>)[^>]*<\/title>/, () => `<title>${safeTitle}</title>`);
 
     // replace description
+    const safeDescription = escapeHtml(recipe.description.split('\n')[0]);
     index = index
       .replaceAll(
         /(<meta\s+(?:property|name)="[^"]*description"\s+content=")[^"]*(">)/g,
-        (_, p1, p2) => `${p1}${recipe.description.split('\n')[0]} ...${p2}`,
+        (_, p1, p2) => `${p1}${safeDescription} ...${p2}`,
       )
       .replace(
         /(<description>)[^>]*<\/description>/,
-        `<description>${recipe.description.split('\n')[0]} ...</description>`,
+        () => `<description>${safeDescription} ...</description>`,
       );
 
-    // replace url
-    const uniqueUrl = `https://${req.headers.host}${req.url}`;
+    // replace url (Host header is attacker-controlled, escape it)
+    const uniqueUrl = escapeHtml(`https://${req.headers.host}${req.url}`);
     index = index.replaceAll(
       /(<meta\s+(?:property|name)="[^"]*url"\s+content=")[^"]*(">)/g,
       (_, p1, p2) => `${p1}${uniqueUrl}${p2}`,
@@ -74,10 +86,12 @@ app.get(['/uniqueRecipes/*slug', '/recipes/*slug'], async (req, res) => {
 
     // replace image
     if (recipe.image.length > 0) {
+      const safeImageUrl = escapeHtml(
+        `https://${req.headers.host}/api/images/${recipe.image}?w=1500&h=1500`,
+      );
       index = index.replaceAll(
         /(<meta\s+(?:property|name)="[^"]*image"\s+content=")[^"]*(">)/g,
-        (_, p1, p2) =>
-          `${p1}https://${req.headers.host}/api/images/${recipe.image}?w=1500&h=1500${p2}`,
+        (_, p1, p2) => `${p1}${safeImageUrl}${p2}`,
       );
     }
     res.send(index);


### PR DESCRIPTION
Fixes the issues found in the security review. Ordered by severity.

## Critical
- **Stored/reflected XSS in SSR meta-injection** (`ui/server/src/server.ts`): user-controlled `recipe.title`/`description`, the shopping-list name, and Host-derived URLs were interpolated into the HTML shell (`<title>`, `<meta content="…">`) with no escaping, so a recipe/shared-link title like `</title><script>…</script>` executed for anyone opening the (publicly shareable) `/recipes/<id>` or `/uniqueRecipes/<uuid>` page. Now escaped with the proven `escape-html` package; the two string-`replace` calls became function replacers so `$`-patterns in attacker input aren't expanded.
- **Content-Security-Policy** (`proxy/nginx.conf`): added as `Content-Security-Policy-Report-Only` first (defense-in-depth) — validate against the running SPA in the console, then flip the header name to enforcing.

## High
- **Unauthenticated shopping-list IDOR** (`api/app.py`): `/shoppingLists/<id>` had no auth and shared a keyspace with private lists (keyed by bare username), so `/shoppingLists/<victim-username>` returned their private list. Now: the private list is served only to its authenticated owner (`list_id == session user`); shared lists must be UUID-shaped and are stored namespaced under `shared:` — so a shared id can never address a private list or a `session:*` key. Public-by-link sharing is preserved. One-time migration in `api/migrate_shopping_lists.py` (run `docker compose exec api python migrate_shopping_lists.py`).
- **`EXPRESS_SECRET`**: removed the `?? 'Apple'` fallback in `server.ts` (throws if unset); constant-time (`hmac.compare_digest`, byte-compared) check on the API side.

## Medium
- **`ImageAPI.delete`**: now requires write access (read-only users got 200 before); returns 404 when the file is absent.
- **Self-registration → group 0**: `addUser` assigns new users to group `0` (write retained, per request). Companion fix: `notifyNewRecipe` now only push-notifies subscribers in the recipe author's group, so a group-0 user can't push-spam everyone.

## Low / hardening
- `SESSION_COOKIE_SECURE = True`.
- PIL decompression-bomb guard (`Image.MAX_IMAGE_PIXELS` + catch `DecompressionBombError`) on upload and resize.

## Follow-ups (maintainer)
- After Report-Only validation, switch CSP to the enforcing header name.
- Production secrets confirmed already strong (no rotation needed).

## Verification done
- `ui/server`: `npm run build && lint && format:check` (Node 24) ✅
- `api`: `black --check . && isort --check . && pyright && flake8` ✅
- Not yet exercised against the live stack — recommend loading `/recipes/<id>` with a `</title><script>…` title on `:3040` and `curl`-ing `/api/shoppingLists/<otherUsername>` to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)