### PR TITLE
fix(client): back off shopping-list SSE reconnects

### DIFF
--- a/ui/client/src/components/ShoppingList.tsx
+++ b/ui/client/src/components/ShoppingList.tsx
@@ -647,9 +647,14 @@ export default function ShoppingList(props: IDarkThemeProps) {
   useEffect(() => {
     if (online) {
       setSynced('initial-fetch');
-      let eventSource = new EventSource(getShoppingListUrl(state.active));
+      let eventSource: EventSource;
+      let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+      // exponential backoff on reconnect (EventSource hides the HTTP status);
+      // resets to instant on any received message
+      let retryDelay = 0;
 
       const onMessage = (v: MessageEvent) => {
+        retryDelay = 0;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const result = JSON.parse(v.data) as IShoppingItem[] | null;
         if (result) {
@@ -669,14 +674,18 @@ export default function ShoppingList(props: IDarkThemeProps) {
       };
       const onError = () => {
         eventSource.close();
+        reconnectTimer = setTimeout(connect, retryDelay + Math.random() * 500);
+        retryDelay = retryDelay === 0 ? 1000 : Math.min(retryDelay * 2, 30000);
+      };
+      const connect = () => {
         eventSource = new EventSource(getShoppingListUrl(state.active));
         eventSource.onmessage = onMessage;
         eventSource.onerror = onError;
       };
 
-      eventSource.onmessage = onMessage;
-      eventSource.onerror = onError;
+      connect();
       return () => {
+        clearTimeout(reconnectTimer);
         eventSource.close();
       };
     } else {


### PR DESCRIPTION
## Problem
The shopping-list `EventSource` reconnect handler reopened the stream with **zero delay** on any error. Combined with the server now ending the stream cleanly on Redis errors (#113), a Redis outage would make every connected client spin in a tight, no-delay reconnect loop — hammering the API exactly when it's already degraded.

## Fix
Exponential backoff with jitter on reconnect (1s → 2s → … → 30s cap), reset to instant the moment any message arrives, so healthy operation still reconnects fast after a transient blip.

### Why not "only on 502"?
The native `EventSource` API surfaces a status-less error event — JS never sees the HTTP code, so 502 can't be singled out without rewriting the stream on `fetch`+`ReadableStream`. Backoff-on-all-failures with reset-on-success is the equivalent that needs no status code.

## Verification
Client `tsc`, `eslint`, and `prettier` all clean. No JS unit-test runner exists in the client (Playwright e2e only), so this is covered by type/lint + the existing e2e flow rather than a new unit test.